### PR TITLE
Bugfix: pressing twice to toggle the menu

### DIFF
--- a/easy-side-menu.js
+++ b/easy-side-menu.js
@@ -22,7 +22,9 @@
    
             // create a one-time event to close when a user clicks anywhere outside
             $(document).one('touchstart click', function(){
-              slideoutMenu.toggleClass("open");
+              if (slideoutMenu.hasClass("open")) {
+                slideoutMenu.toggleClass("open");
+              }
               slideoutMenu.animate({left: -slideoutMenuWidth}, 250); 
             });
           } else {


### PR DESCRIPTION
Fixed the issue that the button to toggle the slide-out menu needs to be pressed twice (i.e. when navigating pages).

Because the class “open” is toggled when the user clicks anywhere on the screen that’s not inside the menu’s boundaries, the toggle is even triggered when the menu is closed. This means that, for example, when navigating to another page, the user needs to click the menu button twice (because the “open” class got added when clicking on the button to navigate); once for removing the class, and then to add the class and opening the menu.

Added a check around the toggle, to see if the “open” class is present. If it is (that means the menu is open) remove it and toggle the menu.